### PR TITLE
fix: get email from user

### DIFF
--- a/includes/agm-status-processing.php
+++ b/includes/agm-status-processing.php
@@ -48,7 +48,7 @@ class AgmStatusProcessing
 
         $data = new stdClass();
         $data->groupid = $order->get_user()->user_login;
-        $data->email = $order->get_user()->user_login;
+        $data->email = $order->get_user()->user_email;
         $data->displayname = $order->get_billing_first_name() . ' ' . $order->get_billing_last_name();
         foreach ($attributes as $name => $attribute) {
             preg_match('/^nextcloud-(?<type>string|list)-(?<name>.+)/', $name, $matches);


### PR DESCRIPTION
Sometimes the user_login could not be a valid email and with this change we always will use the email if exists