### PR TITLE
fix: prevent error when get timeout

### DIFF
--- a/includes/agm-status-processing.php
+++ b/includes/agm-status-processing.php
@@ -25,7 +25,7 @@ class AgmStatusProcessing
                 ]
             ]
         );
-        if ($return['response']['code'] === 200) {
+        if (is_array($return) && $return['response']['code'] === 200) {
             $order->set_status( 'completed', '', true );
             $order->save();
         }


### PR DESCRIPTION
When we get timeout, the response is an object and not an array